### PR TITLE
Make osqp mex file compatible with MSVC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,9 @@ TAGS
 out/
 *.asv
 
+# Files generated during tests
+code/
+
 # Other data files
 # *.mat
 

--- a/osqp_mex.cpp
+++ b/osqp_mex.cpp
@@ -1132,7 +1132,7 @@ void copyMxStructToSettings(const mxArray* mxPtr, OSQPSettings* settings){
   settings->eps_prim_inf           = (c_float)mxGetScalar(mxGetField(mxPtr, 0, "eps_dual_inf"));
   settings->eps_dual_inf           = (c_float)mxGetScalar(mxGetField(mxPtr, 0, "eps_dual_inf"));
   settings->alpha                  = (c_float)mxGetScalar(mxGetField(mxPtr, 0, "alpha"));
-  settings->linsys_solver          = (enum linsys_solver_type) mxGetScalar(mxGetField(mxPtr, 0, "linsys_solver"));
+  settings->linsys_solver          = (enum linsys_solver_type) (c_int) mxGetScalar(mxGetField(mxPtr, 0, "linsys_solver"));
   settings->delta                  = (c_float)mxGetScalar(mxGetField(mxPtr, 0, "delta"));
   settings->polish                 = (c_int)mxGetScalar(mxGetField(mxPtr, 0, "polish"));
   settings->polish_refine_iter     = (c_int)mxGetScalar(mxGetField(mxPtr, 0, "polish_refine_iter"));

--- a/unittests/codegen_mat_tests.m
+++ b/unittests/codegen_mat_tests.m
@@ -33,7 +33,7 @@ classdef codegen_mat_tests < matlab.unittest.TestCase
             
             % Generate code (supress command window output)
             clear mex
-            cmd = ['testCase.solver.codegen(''code'', ''mexname'', ''emosqp'',', ...
+            cmd = ['testCase.solver.codegen(''./code'', ''mexname'', ''emosqp'',', ...
                   ' ''parameters'', ''matrices'', ''force_rewrite'', true);'];
             evalc(cmd);
 

--- a/unittests/codegen_vec_tests.m
+++ b/unittests/codegen_vec_tests.m
@@ -33,7 +33,8 @@ classdef codegen_vec_tests < matlab.unittest.TestCase
             
             % Generate code (supress command window output)
             clear mex
-            cmd = 'testCase.solver.codegen(''code'', ''mexname'', ''emosqp'', ''force_rewrite'', true);';
+            cmd = ['testCase.solver.codegen(''./code'', ''mexname'', ''emosqp'',',....
+                   ' ''force_rewrite'', true);'];
             evalc(cmd);
 
             % Get options


### PR DESCRIPTION
Fix an issue with visual studio not accepting the type conversion of the linear solver parameter. This now makes osqp_mex.cpp compile under visual studio in Matlab.