### PR TITLE
Add error.c/h to the cmake for generated code

### DIFF
--- a/codegen/files_to_generate/CMakeLists.txt
+++ b/codegen/files_to_generate/CMakeLists.txt
@@ -127,6 +127,7 @@ set(
     src/osqp/scaling.c
     src/osqp/util.c
     src/osqp/workspace.c
+    src/osqp/error.c
 )
 
 set(
@@ -145,6 +146,7 @@ set(
     include/types.h
     include/util.h
     include/workspace.h
+    include/error.h
 )
 
 if (NOT(EMBEDDED EQUAL 1))


### PR DESCRIPTION
Add the error.c/h files to the cmake for the code generation.