### PR TITLE
Modify embedded code CMake flow

### DIFF
--- a/codegen/files_to_generate/CMakeLists.txt
+++ b/codegen/files_to_generate/CMakeLists.txt
@@ -113,46 +113,25 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/configure/osqp_configure.h.in
 # ----------------------------------------------
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-
 # Set sources
 # ----------------------------------------------
-set(
-    osqp_src
-    src/osqp/auxil.c
-    src/osqp/lin_alg.c
-    src/osqp/osqp.c
-    src/osqp/proj.c
-    src/osqp/qdldl.c
-    src/osqp/qdldl_interface.c
-    src/osqp/scaling.c
-    src/osqp/util.c
-    src/osqp/workspace.c
-    src/osqp/error.c
-)
+add_subdirectory (src/osqp)
+add_subdirectory (include)
 
-set(
-    osqp_headers
-    include/auxil.h
-    include/constants.h
-    include/glob_opts.h
-    include/osqp_configure.h
-    include/lin_alg.h
-    include/osqp.h
-    include/proj.h
-    include/qdldl.h
-    include/qdldl_interface.h
-    include/qdldl_types.h
-    include/scaling.h
-    include/types.h
-    include/util.h
-    include/workspace.h
-    include/error.h
+# Append the generated workspace files and qdldl files
+list (APPEND
+      osqp_src
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/osqp/workspace.c
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/osqp/qdldl.c
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/osqp/qdldl_interface.c
 )
-
-if (NOT(EMBEDDED EQUAL 1))
-	set (osqp_src ${osqp_src} src/osqp/kkt.c)
-	set (osqp_headers ${osqp_headers} include/kkt.h)
-endif()
+list (APPEND
+      osqp_headers
+      ${CMAKE_CURRENT_SOURCE_DIR}/include/workspace.h
+      ${CMAKE_CURRENT_SOURCE_DIR}/include/qdldl.h
+      ${CMAKE_CURRENT_SOURCE_DIR}/include/qdldl_types.h
+      ${CMAKE_CURRENT_SOURCE_DIR}/include/qdldl_interface.h
+)
 
 # Create static library for embedded solver
 add_library (emosqpstatic STATIC ${osqp_src} ${osqp_headers})

--- a/codegen/make_emosqp.m
+++ b/codegen/make_emosqp.m
@@ -8,6 +8,12 @@ mex_cmd = sprintf('mex -O -silent');
 % Add arguments to mex compiler
 mexoptflags = '-DMATLAB';
 
+% If running on linux, include the c99 option so GCC uses c99 to compile.
+% Otherwise it will throw errors about the comment style
+if ( ~ismac() && isunix() )
+    mexoptflags = sprintf('%s CFLAGS="$CFLAGS -std=c99"', mexoptflags);
+end
+
 % Add embedded flag
 cmake_args = sprintf('-DEMBEDDED:INT=%i', EMBEDDED_FLAG);
 

--- a/make_osqp.m
+++ b/make_osqp.m
@@ -251,8 +251,13 @@ if( any(strcmpi(what,'codegen')) || any(strcmpi(what,'all')) )
                 fullfile(cg_configure_dir, configure_files(i).name));
         end
     end
-
-
+    
+    % Copy cmake files    
+    copyfile(fullfile(osqp_dir, 'src', 'CMakeLists.txt'), ...
+                    fullfile(cg_src_dir, 'CMakeLists.txt'));
+    copyfile(fullfile(osqp_dir, 'include', 'CMakeLists.txt'), ...
+                    fullfile(cg_include_dir, 'CMakeLists.txt'));
+                
     fprintf('\t\t\t\t\t[done]\n');
 
 end

--- a/osqp.m
+++ b/osqp.m
@@ -497,6 +497,12 @@ classdef osqp < handle
                         fullfile(target_include_dir, hfiles(i).name));
                 end
             end
+
+                % Copy cmake files
+            copyfile(fullfile(cdir, 'CMakeLists.txt'), ...
+                    fullfile(target_src_dir, 'osqp', 'CMakeLists.txt'));
+            copyfile(fullfile(hdir, 'CMakeLists.txt'), ...
+                    fullfile(target_include_dir, 'CMakeLists.txt'));
             fprintf('[done]\n');
 
             % Copy example.c


### PR DESCRIPTION
This is the complimentary change to the CMake modifications done in the main OSQP repo (https://github.com/oxfordcontrol/osqp/pull/174) that create a per-source directory CMakeLists.txt file. This allows new files to be added without requiring changes on the embedded code generation side.

This modifies the embedded CMakeLists.txt to reference the new CMakeLists.txt files, and copy them into the generated code folder as well.

There is an additional commit in there to add the C99 flag to the emosqp mex call, since some Matlab versions still don't use it natively (e.g. my R2016b on Linux doesn't).

These should be the only changes needed in the Matlab interface. Python will need the same changes made.