### PR TITLE
Check A dimensions match P

### DIFF
--- a/osqp.m
+++ b/osqp.m
@@ -205,6 +205,7 @@ classdef osqp < handle
                 m = 0;
             else
                 m = size(A, 1);
+                assert(size(A, 2) == n, 'Incorrect dimension of A');
             end
 
             %


### PR DESCRIPTION
The second dimension of A is not currently checked, so it won't be detected when `size(A,2) ~= size(P,1)`. In the mex, this can result in using uninitialized memory when they don't match. For me it showed up as `nnz(A)` being uninitialized causing a malloc failure.