### PR TITLE
Clarify location of the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ where `x in R^n` is the optimization variable. The objective function is defined
 
 
 ## Documentation
-The interface is documented [here](https://osqp.org/).
+  The installation procedure is documented in [https://osqp.org/docs/get_started/matlab.html](https://osqp.org/docs/get_started/matlab.html), while the interface is documented in [https://osqp.org/docs/interfaces/matlab.html](https://osqp.org/docs/interfaces/matlab.html).


### PR DESCRIPTION
It may be just my impression, but going from https://osqp.org/ to the actual pages for the installation and use of interface is a bit confusing, so I added direct links. However this is largely a matter of taste, so feel free to decline the PR, thanks! 