### PR TITLE
Add GitHub workflow to test MATLAB interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,5 +40,6 @@ jobs:
       - name: Publish Test Results
         uses: mikepenz/action-junit-report@v2
         with:
+          fail_on_failure: true
           check_name: Test results
           report_paths: 'test-results/**/*.xml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,13 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
@@ -29,5 +35,5 @@ jobs:
       - name: Publish Test Results
         uses: mikepenz/action-junit-report@v2
         with:
-          check_name: Linux test results
+          check_name: ${{ matrix.os }} test results
           report_paths: 'test-results/**/*.xml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,5 @@ jobs:
       - name: Publish Test Results
         uses: mikepenz/action-junit-report@v2
         with:
+          check_name: Linux test results
           report_paths: 'test-results/**/*.xml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,14 @@ jobs:
         with:
           command: make_osqp
 
-      - name: Run tests and generate artifacts
+      - name: Run tests
         uses: matlab-actions/run-tests@v1
         with:
           source-folder: ./
           select-by-folder: unittests
           test-results-junit: test-results/results.xml
+
+      - name: Publish Test Results
+        uses: mikepenz/action-junit-report@v2
+        with:
+          report_paths: 'test-results/**/*.xml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,17 @@ on: [push, pull_request]
 
 jobs:
   build:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+    # As of May 28, 2021 Matlab isn't able to be used on Windows or Linux on GitHub shared runners
+    # (it errors saying the dependencies aren't available on those platforms). Instead we can only
+    # test on ubuntu-latest. The matrix below is preserved here in case Matlab support is added
+    # to those other platforms.
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        os: [ubuntu-latest, macos-latest, windows-latest]
 
-    runs-on: ${{ matrix.os }}
+#    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out repository
@@ -35,5 +40,5 @@ jobs:
       - name: Publish Test Results
         uses: mikepenz/action-junit-report@v2
         with:
-          check_name: ${{ matrix.os }} test results
+          check_name: Test results
           report_paths: 'test-results/**/*.xml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: Test OSQP Matlab Interface
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Install MATLAB
+        uses: matlab-actions/setup-matlab@v1
+
+      - name: Build OSQP interface
+        uses: matlab-actions/run-command@v1
+        with:
+          command: make_osqp
+
+      - name: Run tests and generate artifacts
+        uses: matlab-actions/run-tests@v1
+        with:
+          source-folder: ./
+          select-by-folder: unittests
+          test-results-junit: test-results/results.xml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Matlab interface for OSQP
 
+[![Matlab Interface Tests](https://github.com/oxfordcontrol/osqp-matlab/actions/workflows/ci.yml/badge.svg)](https://github.com/oxfordcontrol/osqp-matlab/actions/workflows/ci.yml)
+
 Matlab wrapper for [OSQP](https://osqp.org/): the Operator Splitting QP Solver.
 
 The OSQP (Operator Splitting Quadratic Program) solver is a numerical optimization package for solving problems in the form


### PR DESCRIPTION
I discovered that MathWorks provides Matlab on shared GitHub runners, and even has written some actions that make running Matlab tests very easy. This is currently just a simple test on Linux only, but I am going to work on expanding it to Windows and macOS too hopefully (since I believe there are Matlab runners for those as well.