### PR TITLE
Quote mex_cfile path

### DIFF
--- a/codegen/make_emosqp.m
+++ b/codegen/make_emosqp.m
@@ -68,7 +68,7 @@ end
 fprintf('Compiling and linking osqpmex...');
 
 % Compile command
-cmd = sprintf('%s %s %s %s %s', mex_cmd, mexoptflags, inc_dir, mex_cfile, cfiles);
+cmd = sprintf('%s %s %s "%s" %s', mex_cmd, mexoptflags, inc_dir, mex_cfile, cfiles);
 
 % Compile
 eval(cmd);


### PR DESCRIPTION
While exploring alternate ways to install OSQP Matlab on Linux, I observe that OSQP, when installed through 'add-on explorer' or through a `.mlappinstall` file, is installed by default at:
```
/home/vineetb/MATLAB Add-Ons/Collections/OSQP
```
i.e. at a location with spaces in its path. This causes `codegen` to fail. Quoting the path where `mex_cfile` is expected to be found solves the problem.

There are likely other places where quoting would solve similar issues, but this seems more important since this will typically be outside user control.