### PR TITLE
Update osqp.m

### DIFF
--- a/osqp.m
+++ b/osqp.m
@@ -532,10 +532,10 @@ classdef osqp < handle
             if ~isempty(project_type)
 	    
                 % Extend path for CMake mac (via Homebrew)
-		PATH = getenv('PATH');
-		if ((ismac) && (isempty(strfind(PATH, '/usr/local/bin'))))
-		    setenv('PATH', [PATH ':/usr/local/bin']);
-		end
+                PATH = getenv('PATH');
+                if ((ismac) && (isempty(strfind(PATH, '/usr/local/bin'))))
+                    setenv('PATH', [PATH ':/usr/local/bin']);
+                end
     
                 fprintf('Creating project...\t\t\t\t\t\t\t\t');
                 orig_dir = pwd;

--- a/osqp.m
+++ b/osqp.m
@@ -530,6 +530,13 @@ classdef osqp < handle
 
             % Create project
             if ~isempty(project_type)
+	    
+                % Extend path for CMake mac (via Homebrew)
+		PATH = getenv('PATH');
+		if ((ismac) && (isempty(strfind(PATH, '/usr/local/bin'))))
+		    setenv('PATH', [PATH ':/usr/local/bin']);
+		end
+    
                 fprintf('Creating project...\t\t\t\t\t\t\t\t');
                 orig_dir = pwd;
                 cd(target_dir);


### PR DESCRIPTION
For code generation on Mac OS X, the location `usr/local/bin` needs to be added to the `PATH` to find `cmake` installed through homebrew. This change mirrors exactly what `make_osqp.m` is also already doing here:

https://github.com/osqp/osqp-matlab/blob/828a93b70a6430f78d79828fa090aee0a79850d6/make_osqp.m#L143