### PR TITLE
Pin MATLAB version to R2023a

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,9 @@ jobs:
 
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v1
+        with:
+          # Use R2023a due to a licensing bug with R2023b and the GitHub actions shared runners
+          release: R2023a
 
       - name: Build OSQP interface
         uses: matlab-actions/run-command@v1


### PR DESCRIPTION
There is a bug in R2023b and the shared GitHub actions runners that causes a licensing issue on Windows runners, preventing the test suite from running. For now, pin the MATLAB version to the last working version until the action is updated.