### PR TITLE
Use OSQPCscMatrix_free to free memory allocated with OSQPCscMatrix_new

### DIFF
--- a/c_sources/osqp_mex.cpp
+++ b/c_sources/osqp_mex.cpp
@@ -368,8 +368,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         if (dataQ)    c_free(dataQ);
         if (dataL)    c_free(dataL);
         if (dataU)    c_free(dataU);
-        if (dataP)    c_free(dataP);
-        if (dataA)    c_free(dataA);
+        if (dataP)    OSQPCscMatrix_free(dataP);
+        if (dataA)    OSQPCscMatrix_free(dataA);
 
         // Report error (if any)
         if(exitflag){


### PR DESCRIPTION
Similar to https://github.com/osqp/osqp-matlab/pull/34 but for 1.0 .