### PR TITLE
Remove unused error.h header

### DIFF
--- a/c_sources/osqp_mex.hpp
+++ b/c_sources/osqp_mex.hpp
@@ -1,7 +1,6 @@
 #ifndef __OSQP_MEX_HPP__
 #define __OSQP_MEX_HPP__
 #include "mex.h"
-#include "error.h"
 #include <stdint.h>
 #include <string>
 #include <cstring>


### PR DESCRIPTION
`error.h` only defines the `osqp_error` function, but it does not seem that `osqp_error` is used in `osqp-matlab`.